### PR TITLE
Resolve misc display issues

### DIFF
--- a/css/sitestudio-gin-global.css
+++ b/css/sitestudio-gin-global.css
@@ -15,10 +15,18 @@
   mask-repeat: no-repeat;
   -webkit-mask-position: center center;
   mask-position: center center;
-  -webkit-mask-size: var(--iconGinToolbar) var(--iconGinToolbar);
-  mask-size: var(--iconGinToolbar) var(--iconGinToolbar);
+  -webkit-mask-size: contain;
+  mask-size: contain;
 }
 
 .ssa-element-browser-modal-open {
     padding-left: 320px !important;
+}
+
+[dir="ltr"] body.gin--vertical-toolbar.ssa-page-builder-enabled {
+  padding-left: 0;
+}
+
+body.gin--horizontal-toolbar.ssa-page-builder-enabled .gin-secondary-toolbar {
+  display: none;
 }


### PR DESCRIPTION
Fixes:
- icon being cropped in secondary toolbar for Page Builder link
- Left padding in Page Builder with left toolbar
- Edit link visible at top in Page Builder when using top (not Classic) toolbar